### PR TITLE
Add verification and public key importing

### DIFF
--- a/atecc608a_utils.c
+++ b/atecc608a_utils.c
@@ -23,7 +23,7 @@
 
 #include "atca_basic.h"
 
-psa_status_t atecc608a_get_serial_number(uint8_t* buffer,
+psa_status_t atecc608a_get_serial_number(uint8_t *buffer,
                                          size_t buffer_size,
                                          size_t *buffer_length)
 {
@@ -62,7 +62,7 @@ exit:
     return status;
 }
 
-psa_status_t atecc608a_genKey(uint16_t slot, uint8_t* pubkey, size_t pubkey_size)
+psa_status_t atecc608a_generate_key(uint16_t slot, uint8_t *pubkey, size_t pubkey_size)
 {
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
     if (pubkey != NULL && pubkey_size < ATCA_PUB_KEY_SIZE)

--- a/atecc608a_utils.c
+++ b/atecc608a_utils.c
@@ -61,3 +61,19 @@ exit:
     }
     return status;
 }
+
+psa_status_t atecc608a_genKey(uint16_t slot, uint8_t* pubkey, size_t pubkey_size)
+{
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+    if (pubkey != NULL && pubkey_size < ATCA_PUB_KEY_SIZE)
+    {
+       return PSA_ERROR_BUFFER_TOO_SMALL;
+    }
+
+    ASSERT_SUCCESS_PSA(atecc608a_init());
+    ASSERT_SUCCESS(atcab_genkey(slot, pubkey));
+
+exit:
+    atecc608a_deinit();
+    return status;
+}

--- a/atecc608a_utils.h
+++ b/atecc608a_utils.h
@@ -56,11 +56,11 @@
 #define ASSERT_SUCCESS_PSA(expression) ASSERT_STATUS(expression, PSA_SUCCESS, \
                                                      ASSERT_result)
 
-psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size,
+psa_status_t atecc608a_get_serial_number(uint8_t *buffer, size_t buffer_size,
                                          size_t *buffer_length);
 
 psa_status_t atecc608a_check_config_locked();
 
-psa_status_t atecc608a_genKey(uint16_t slot, uint8_t* pubkey, size_t pubkey_size);
+psa_status_t atecc608a_generate_key(uint16_t slot, uint8_t *pubkey, size_t pubkey_size);
 
 #endif /* ATECC608A_SE_H */

--- a/atecc608a_utils.h
+++ b/atecc608a_utils.h
@@ -61,4 +61,6 @@ psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size,
 
 psa_status_t atecc608a_check_config_locked();
 
+psa_status_t atecc608a_genKey(uint16_t slot, uint8_t* pubkey, size_t pubkey_size);
+
 #endif /* ATECC608A_SE_H */

--- a/main.c
+++ b/main.c
@@ -171,12 +171,11 @@ int main(void)
                          atecc608a_key_slot_device, pubkey, sizeof(pubkey),
                          &pubkey_len));
 
-    /* Import a subset of the key, omitting the 0x04 prefix - only raw X & Y */
     ASSERT_SUCCESS_PSA(atecc608a_drv_info.p_key_management->p_import(
                          atecc608a_public_key_slot,
                          atecc608a_drv_info.lifetime,
-                         key_type, alg, PSA_KEY_USAGE_VERIFY, pubkey+1,
-                         pubkey_len-1));
+                         key_type, alg, PSA_KEY_USAGE_VERIFY, pubkey,
+                         pubkey_len));
 
     ASSERT_SUCCESS_PSA(atecc608a_drv_info.p_asym->p_sign(
                          atecc608a_key_slot_device, alg, hash, sizeof(hash),

--- a/main.c
+++ b/main.c
@@ -147,7 +147,7 @@ int main(void)
 
     atecc608a_print_serial_number();
     atecc608a_print_config_zone();
-    ASSERT_SUCCESS_PSA(atecc608a_generate_key(0, pubkey, pubkey_size));
+    ASSERT_SUCCESS_PSA(atecc608a_generate_key(atecc608a_key_slot_device, pubkey, pubkey_size));
     atcab_printbin_label("pubKey generated: ", pubkey, ATCA_PUB_KEY_SIZE);
 
     ASSERT_SUCCESS_PSA(atecc608a_hash_sha256(hash_input1,

--- a/main.c
+++ b/main.c
@@ -147,7 +147,7 @@ int main(void)
 
     atecc608a_print_serial_number();
     atecc608a_print_config_zone();
-    ASSERT_SUCCESS_PSA(atecc608a_genKey(0, pubkey, pubkey_size));
+    ASSERT_SUCCESS_PSA(atecc608a_generate_key(0, pubkey, pubkey_size));
     atcab_printbin_label("pubKey generated: ", pubkey, ATCA_PUB_KEY_SIZE);
 
     ASSERT_SUCCESS_PSA(atecc608a_hash_sha256(hash_input1,

--- a/main.c
+++ b/main.c
@@ -105,6 +105,18 @@ exit:
     return status;
 }
 
+psa_status_t atecc608a_print_config_zone()
+{
+    uint8_t config_buffer[ATCA_ECC_CONFIG_SIZE] = {0};
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+    ASSERT_SUCCESS_PSA(atecc608a_init());
+    ASSERT_SUCCESS(atcab_read_config_zone(config_buffer));
+    atcab_printbin_label("Config zone: ", config_buffer, ATCA_ECC_CONFIG_SIZE);
+exit:
+    atecc608a_deinit();
+    return status;
+}
+
 int main(void)
 {
     enum {
@@ -131,8 +143,12 @@ int main(void)
     static uint8_t pubkey[pubkey_size];
     size_t pubkey_len = 0;
     psa_key_slot_number_t atecc608a_key_slot_device = 0;
+    psa_key_slot_number_t atecc608a_public_key_slot = 9;
 
     atecc608a_print_serial_number();
+    atecc608a_print_config_zone();
+    ASSERT_SUCCESS_PSA(atecc608a_genKey(0, pubkey, pubkey_size));
+    atcab_printbin_label("pubKey generated: ", pubkey, ATCA_PUB_KEY_SIZE);
 
     ASSERT_SUCCESS_PSA(atecc608a_hash_sha256(hash_input1,
                                              sizeof(hash_input1) - 1,
@@ -147,6 +163,7 @@ int main(void)
     ASSERT_SUCCESS_PSA(psa_crypto_init());
 
     atecc608a_print_locked_zones();
+
     /* Verify that the device has a locked config before doing anything */
     ASSERT_SUCCESS_PSA(atecc608a_check_config_locked());
 
@@ -154,10 +171,20 @@ int main(void)
                          atecc608a_key_slot_device, pubkey, sizeof(pubkey),
                          &pubkey_len));
 
+    /* Import a subset of the key, omitting the 0x04 prefix - only raw X & Y */
+    ASSERT_SUCCESS_PSA(atecc608a_drv_info.p_key_management->p_import(
+                         atecc608a_public_key_slot,
+                         atecc608a_drv_info.lifetime,
+                         key_type, alg, PSA_KEY_USAGE_VERIFY, pubkey+1,
+                         pubkey_len-1));
+
     ASSERT_SUCCESS_PSA(atecc608a_drv_info.p_asym->p_sign(
                          atecc608a_key_slot_device, alg, hash, sizeof(hash),
                          signature, sizeof(signature), &signature_length));
 
+    ASSERT_SUCCESS_PSA(atecc608a_drv_info.p_asym->p_verify(
+                         atecc608a_public_key_slot, alg, hash, sizeof(hash),
+                         signature, signature_length));
     /*
      * Import the secure element's public key into a volatile key slot.
      */


### PR DESCRIPTION
This PR has a prerequisite of https://github.com/ARMmbed/mbed-os-atecc608a/pull/4.
Hardware prerequisites:
- private, writable key slot configured at slot #0;
- public, writable key slot at slot #9.

This PR adds tests for hardware verification with a key exported from hardware to PSA format and imported back to hardware, modifying the format back.
It also adds key generation in slot 0, just in case if it's not there yet.

Unfortunately, with current version of cryptoauthlib, there is a bug in the `write` command implementation which causes development boards with unlocked data zones to fail when importing public keys.
Here's the responsible code that we currently use: https://github.com/janjongboom/cryptoauthlib/blob/49eee05e5b2a4dbd96d2fff68b32dce28f3a0a9b/lib/basic/atca_basic_write.c#L379
And a fixed version in a newer version of the library: https://github.com/MicrochipTech/cryptoauthlib/blob/76ccc87aebf3ac10dca99317fed57ee1921b2ef5/lib/basic/atca_basic_write.c#L376

Updating to a working version of the library or supplying a patch is not yet handled. The code has been tested and works with the new version of the mentioned function (not tested with a whole new version of library).