### PR TITLE
Use the driver version of private key generation

### DIFF
--- a/atecc608a_utils.c
+++ b/atecc608a_utils.c
@@ -61,19 +61,3 @@ exit:
     }
     return status;
 }
-
-psa_status_t atecc608a_generate_key(uint16_t slot, uint8_t *pubkey, size_t pubkey_size)
-{
-    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
-    if (pubkey != NULL && pubkey_size < ATCA_PUB_KEY_SIZE)
-    {
-       return PSA_ERROR_BUFFER_TOO_SMALL;
-    }
-
-    ASSERT_SUCCESS_PSA(atecc608a_init());
-    ASSERT_SUCCESS(atcab_genkey(slot, pubkey));
-
-exit:
-    atecc608a_deinit();
-    return status;
-}

--- a/atecc608a_utils.h
+++ b/atecc608a_utils.h
@@ -61,6 +61,4 @@ psa_status_t atecc608a_get_serial_number(uint8_t *buffer, size_t buffer_size,
 
 psa_status_t atecc608a_check_config_locked();
 
-psa_status_t atecc608a_generate_key(uint16_t slot, uint8_t *pubkey, size_t pubkey_size);
-
 #endif /* ATECC608A_SE_H */

--- a/main.c
+++ b/main.c
@@ -178,7 +178,7 @@ int main(void)
                          key_type, alg, PSA_KEY_USAGE_VERIFY, pubkey,
                          pubkey_len));
 
-    /* Test that a public key that is exported from a private key - can be
+    /* Test that a public key that is exported from a private key can be
      * imported */
     ASSERT_SUCCESS_PSA(atecc608a_drv_info.p_key_management->p_export(
                          atecc608a_key_slot_device, pubkey, sizeof(pubkey),

--- a/main.c
+++ b/main.c
@@ -147,8 +147,13 @@ int main(void)
 
     atecc608a_print_serial_number();
     atecc608a_print_config_zone();
-    ASSERT_SUCCESS_PSA(atecc608a_generate_key(atecc608a_key_slot_device, pubkey, pubkey_size));
-    atcab_printbin_label("pubKey generated: ", pubkey, ATCA_PUB_KEY_SIZE);
+
+    ASSERT_SUCCESS_PSA(atecc608a_drv_info.p_key_management->p_generate(
+                         atecc608a_key_slot_device, keypair_type,
+                         PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY,
+                         key_bits, NULL, 0, pubkey, pubkey_size, &pubkey_len));
+
+    atcab_printbin_label("pubKey generated: ", pubkey, pubkey_len);
 
     ASSERT_SUCCESS_PSA(atecc608a_hash_sha256(hash_input1,
                                              sizeof(hash_input1) - 1,

--- a/mbed-os-atecc608a.lib
+++ b/mbed-os-atecc608a.lib
@@ -1,1 +1,1 @@
-git@github.com:ARMmbed/mbed-os-atecc608a/#b43091e170053864a0cf1199186160e8e7ffc337
+https://github.com/ARMmbed/mbed-os-atecc608a/#bae7de43d835aea03c4fd7af382232d8b5d26ad7


### PR DESCRIPTION
This PR has a prerequisite of https://github.com/ARMmbed/mbed-os-atecc608a/pull/5.