### PR TITLE
Test clear text writing to and reading from a slot

### DIFF
--- a/atecc608a_utils.c
+++ b/atecc608a_utils.c
@@ -62,13 +62,18 @@ exit:
     return status;
 }
 
-psa_status_t atecc608a_random(uint8_t *rand_out)
+psa_status_t atecc608a_random_32_bytes(uint8_t *rand_out, size_t buffer_size)
 {
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
     if (rand_out == NULL)
     {
         return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (buffer_size < 32)
+    {
+        return PSA_ERROR_BUFFER_TOO_SMALL;
     }
 
     ASSERT_SUCCESS_PSA(atecc608a_init());

--- a/atecc608a_utils.c
+++ b/atecc608a_utils.c
@@ -61,3 +61,20 @@ exit:
     }
     return status;
 }
+
+psa_status_t atecc608a_random(uint8_t *rand_out)
+{
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+
+    if (rand_out == NULL)
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    ASSERT_SUCCESS_PSA(atecc608a_init());
+    ASSERT_SUCCESS(atcab_random(rand_out));
+
+exit:
+    atecc608a_deinit();
+    return status;
+}

--- a/atecc608a_utils.h
+++ b/atecc608a_utils.h
@@ -62,6 +62,6 @@ psa_status_t atecc608a_get_serial_number(uint8_t *buffer, size_t buffer_size,
 psa_status_t atecc608a_check_config_locked();
 
 /** Generate a 32 byte random number from the CryptoAuth device. */
-psa_status_t atecc608a_random(uint8_t *rand_out);
+psa_status_t atecc608a_random_32_bytes(uint8_t *rand_out, size_t buffer_size);
 
 #endif /* ATECC608A_SE_H */

--- a/atecc608a_utils.h
+++ b/atecc608a_utils.h
@@ -61,4 +61,7 @@ psa_status_t atecc608a_get_serial_number(uint8_t *buffer, size_t buffer_size,
 
 psa_status_t atecc608a_check_config_locked();
 
+/** Generate a 32 byte random number from the CryptoAuth device. */
+psa_status_t atecc608a_random(uint8_t *rand_out);
+
 #endif /* ATECC608A_SE_H */

--- a/main.c
+++ b/main.c
@@ -124,7 +124,7 @@ psa_status_t test_write_read_slot(uint16_t slot)
     uint8_t data_write[TEST_WRITE_READ_SIZE] = {};
     uint8_t data_read[TEST_WRITE_READ_SIZE] = {};
 
-    ASSERT_SUCCESS_PSA(atecc608a_random(data_write));
+    ASSERT_SUCCESS_PSA(atecc608a_random_32_bytes(data_write, TEST_WRITE_READ_SIZE));
     ASSERT_SUCCESS_PSA(atecc608a_write(slot, 0, data_write, TEST_WRITE_READ_SIZE));
     ASSERT_SUCCESS_PSA(atecc608a_read(slot, 0, data_read, TEST_WRITE_READ_SIZE));
     ASSERT_STATUS(memcmp(data_write, data_read, TEST_WRITE_READ_SIZE),

--- a/main.c
+++ b/main.c
@@ -183,6 +183,8 @@ int main(void)
     /* Verify that the device has a locked config before doing anything */
     ASSERT_SUCCESS_PSA(atecc608a_check_config_locked());
 
+    /* Slot 8 is usually used as a clear write and read certificate
+     * or signature slot, as it is the biggest one (416 bytes of space). */
     test_write_read_slot(8);
 
     /* Test that a public key received during a private key generation

--- a/main.c
+++ b/main.c
@@ -117,6 +117,24 @@ exit:
     return status;
 }
 
+#define TEST_WRITE_READ_SIZE 32
+psa_status_t test_write_read_slot(uint16_t slot)
+{
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+    uint8_t data_write[TEST_WRITE_READ_SIZE] = {};
+    uint8_t data_read[TEST_WRITE_READ_SIZE] = {};
+
+    ASSERT_SUCCESS_PSA(atecc608a_random(data_write));
+    ASSERT_SUCCESS_PSA(atecc608a_write(slot, 0, data_write, TEST_WRITE_READ_SIZE));
+    ASSERT_SUCCESS_PSA(atecc608a_read(slot, 0, data_read, TEST_WRITE_READ_SIZE));
+    ASSERT_STATUS(memcmp(data_write, data_read, TEST_WRITE_READ_SIZE),
+                  0, PSA_ERROR_HARDWARE_FAILURE);
+
+    printf("test_write_read_slot succesful!\n");
+exit:
+    return status;
+}
+
 int main(void)
 {
     enum {
@@ -164,6 +182,8 @@ int main(void)
 
     /* Verify that the device has a locked config before doing anything */
     ASSERT_SUCCESS_PSA(atecc608a_check_config_locked());
+
+    test_write_read_slot(8);
 
     /* Test that a public key received during a private key generation
      * can be imported */

--- a/mbed-os-atecc608a.lib
+++ b/mbed-os-atecc608a.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os-atecc608a/#bae7de43d835aea03c4fd7af382232d8b5d26ad7
+https://github.com/ARMmbed/mbed-os-atecc608a/#5f7e5687b935703f3507aa30aaa9de3f2bc104d0

--- a/tests/atecc608a.log
+++ b/tests/atecc608a.log
@@ -4,4 +4,5 @@ Success!
 SHA-256:
 Success!
   - Config locked: 1
+test_write_read_slot succesful!
 Verification successful!


### PR DESCRIPTION
This PR adds a test exercising clear text writes & reads from a slot. Slot 8 has been chosen as it is configured to contain arbitrary data, and clear text writes/reads are enabled on it. Please only review the two read/write commits.

Prerequisites: 
- Hardware with a locked config zone and locked data & OTP zone. Note: This does not mean that the data in data slots cannot be modified - it means that the data slots behave according to the policies set by the configuration. This lock is required in order for clear text reads to work from the device.
- https://github.com/ARMmbed/mbed-os-atecc608a/pull/6.
