### PR TITLE
Fix the version of driver library

### DIFF
--- a/mbed-os-atecc608a.lib
+++ b/mbed-os-atecc608a.lib
@@ -1,1 +1,1 @@
-git@github.com:ARMmbed/mbed-os-atecc608a/#98089e18e7ac02716ec9c78835548a24ea7fc4b8
+git@github.com:ARMmbed/mbed-os-atecc608a/#b43091e170053864a0cf1199186160e8e7ffc337


### PR DESCRIPTION
When merging previous PR's, we forgot to update the version of the driver library. This commit fixes that.