### PR TITLE
Enable building from root directory

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,0 +1,2 @@
+mbed-os/features/frameworks/unity/
+


### PR DESCRIPTION
Duplicate the .mbedignore so that the Mbed OS CI system will be able to
build and test this example. When the Mbed OS CI system can cope with
subfolders containing examples, we can revert this duplication.

Without the .mbedignore, Mbed OS build system chokes on a duplicate
"Unity" library, which is included by both the Mbed OS and cryptoauthlib
projects.