### PR TITLE
Clarify key ID and key slot

### DIFF
--- a/atecc608a/main.c
+++ b/atecc608a/main.c
@@ -76,9 +76,26 @@
     "the slot now behaves according to the policies set by the associated\n"\
     "configuration zone’s values. [y/n]: "
 
-/* Data used by tests */
+/* Physical locations of the keys in the secure element. */
 psa_key_slot_number_t atecc608a_private_key_slot = 1;
 psa_key_slot_number_t atecc608a_public_key_slot = 9;
+
+/* Key IDs used by applications.
+ *
+ * A key ID is a persistent reference to a key. A key ID number is chosen by
+ * applications. Key ID numbers are not tied to the physical location of the
+ * key. (The physical location of a key is determined by the key's lifetime,
+ * and, for a key in a secure element, by its slot number.)
+ *
+ * Note: In order to emphasize that key IDs are distinct from physical secure
+ * element slots, we've chosen key IDs that are outside the range of valid
+ * physical slots for our chosen secure element, the ATECC608A (0 through 15
+ * inclusive). Misuse of a key ID as a slot number will cause the driver to
+ * error. */
+psa_key_id_t atecc608a_private_key_id = 17;
+psa_key_id_t atecc608a_public_key_id = 25;
+psa_key_id_t generated_priv_key_id = 33;
+psa_key_id_t generated_pub_key_id = 41;
 
 enum {
     key_type = PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_CURVE_SECP256R1),
@@ -196,7 +213,7 @@ psa_status_t test_psa_import_verify(psa_key_attributes_t *private_attributes)
     };
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
-    ASSERT_SUCCESS_PSA(psa_open_key(atecc608a_private_key_slot,
+    ASSERT_SUCCESS_PSA(psa_open_key(atecc608a_private_key_id,
                                     &private_handle));
 
     ASSERT_SUCCESS_PSA(psa_asymmetric_sign(private_handle, alg, hash, sizeof(hash),
@@ -241,7 +258,7 @@ psa_status_t test_export_import(psa_key_attributes_t *private_attributes,
     psa_key_handle_t public_handle = 0;
     psa_key_handle_t private_handle = 0;
 
-    ASSERT_SUCCESS_PSA(psa_open_key(atecc608a_private_key_slot,
+    ASSERT_SUCCESS_PSA(psa_open_key(atecc608a_private_key_id,
                                     &private_handle));
 
     ASSERT_SUCCESS_PSA(psa_export_public_key(private_handle, pubkey,
@@ -333,10 +350,11 @@ exit:
 }
 
 void setup_key_attributes(psa_key_attributes_t *attributes,
+                          psa_key_id_t key_id,
                           psa_key_slot_number_t slot, int is_private)
 {
     psa_set_key_slot_number(attributes, slot);
-    psa_set_key_id(attributes, slot);
+    psa_set_key_id(attributes, key_id);
     psa_set_key_lifetime(attributes, PSA_ATECC608A_LIFETIME);
     psa_set_key_algorithm(attributes, alg);
     psa_set_key_bits(attributes, key_bits);
@@ -361,9 +379,11 @@ psa_status_t run_tests()
     mbed_psa_reboot_and_request_new_security_state(PSA_LIFECYCLE_ASSEMBLY_AND_TEST);
 
     setup_key_attributes(&public_key_attributes,
+                         atecc608a_public_key_id,
                          atecc608a_public_key_slot, 0);
 
     setup_key_attributes(&private_key_attributes,
+                         atecc608a_private_key_id,
                          atecc608a_private_key_slot, 1);
 
     printf("Running tests...\n");
@@ -453,7 +473,8 @@ bool interactive_loop()
             printf("Invalid slot %u provided for generate_private command.\n", slot);
             return false;
         }
-        setup_key_attributes(&private_attributes, slot, 1);
+        setup_key_attributes(&private_attributes,
+                             generated_priv_key_id, slot, 1);
         printf("Generating a private key in slot %u... ", slot);
         status = psa_generate_key(&private_attributes, &private_handle);
 
@@ -487,11 +508,12 @@ bool interactive_loop()
                    slot_private, slot_public);
             return false;
         }
-        setup_key_attributes(&public_attributes, slot_public, 0);
+        setup_key_attributes(&public_attributes,
+                             generated_pub_key_id, slot_public, 0);
         printf("Exporting a public key from private key in slot %u... ",
                slot_private);
 
-        status = psa_open_key(slot_private, &private_handle);
+        status = psa_open_key(generated_priv_key_id, &private_handle);
         if (status != PSA_SUCCESS) {
             printf("Failed! Error %ld.\n", status);
             return false;

--- a/atecc608a/main.c
+++ b/atecc608a/main.c
@@ -473,7 +473,6 @@ bool interactive_loop()
         psa_key_handle_t public_handle = 0;
         psa_key_handle_t private_handle = 0;
         psa_key_attributes_t public_attributes = PSA_KEY_ATTRIBUTES_INIT;
-        psa_key_attributes_t private_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
         // Check if an argument is missing
         if (len <= strlen("generate_public=0_9") - 1) {
@@ -489,7 +488,6 @@ bool interactive_loop()
             return false;
         }
         setup_key_attributes(&public_attributes, slot_public, 0);
-        setup_key_attributes(&private_attributes, slot_private, 1);
         printf("Exporting a public key from private key in slot %u... ",
                slot_private);
 


### PR DESCRIPTION
Our example is currently confusing because it uses key slot numbers as both key IDs and key slots. This led to some users thinking that key IDs must match what's used as the physical key slot location within a secure element. Make it obvious that key IDs are not the same as key slots. Prevent misuse of key IDs as key slots by making key IDs outside the range the ATECC608A considers valid for its physical key slots.