### PR TITLE
Update mbed-os-atecc608s for cryptoauthlib v3.1.0

### DIFF
--- a/atecc608a/mbed-os-atecc608a.lib
+++ b/atecc608a/mbed-os-atecc608a.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os-atecc608a/#754d0e42acc15f67310c7b3c773cd5b9484b924e
+https://github.com/ARMmbed/mbed-os-atecc608a/#1a94094b396b2bd367b6f8a16928de0556715d69


### PR DESCRIPTION
Update the ATECC608A PSA SE driver for Mbed OS (mbed-os-atecc608a) to a
version that includes cryptoauthlib v3.1.0

Fixes https://github.com/ARMmbed/mbed-os-example-atecc608a/issues/15