### PR TITLE
Fix iar compilation issues

### DIFF
--- a/atecc608a/main.c
+++ b/atecc608a/main.c
@@ -103,7 +103,7 @@ enum {
     key_bits = 256,
     hash_alg = PSA_ALG_SHA_256,
     alg = PSA_ALG_ECDSA(hash_alg),
-    sig_size = PSA_ASYMMETRIC_SIGN_OUTPUT_SIZE(key_type, key_bits, alg),
+    sig_size = PSA_ECDSA_SIGNATURE_SIZE(key_bits),
     pubkey_size = PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(key_bits),
     hash_size = PSA_HASH_SIZE(hash_alg),
 };

--- a/atecc608a/main.c
+++ b/atecc608a/main.c
@@ -281,7 +281,7 @@ psa_status_t test_sign_verify(psa_key_attributes_t *private_attributes,
                               psa_key_attributes_t *public_attributes)
 {
     psa_status_t status;
-    const uint8_t hash[hash_size] = {};
+    const uint8_t hash[hash_size] = {0};
     uint8_t signature[sig_size];
     size_t signature_length = 0;
     static uint8_t pubkey[pubkey_size];

--- a/atecc608a/mbed-os-atecc608a.lib
+++ b/atecc608a/mbed-os-atecc608a.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os-atecc608a/#1a94094b396b2bd367b6f8a16928de0556715d69
+https://github.com/ARMmbed/mbed-os-atecc608a/#04f1cb7c1c760671ac13058dd250ec002455d112


### PR DESCRIPTION
This PR updates the atecc608a driver to include a version of cryptoauthlib that supports IAR.

This uncovered a few issues with IAR that this PR also fixes.