### PR TITLE
Update mbed-os-atecc608a.lib with the latest master

### DIFF
--- a/atecc608a/mbed-os-atecc608a.lib
+++ b/atecc608a/mbed-os-atecc608a.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os-atecc608a/#04f1cb7c1c760671ac13058dd250ec002455d112
+https://github.com/ARMmbed/mbed-os-atecc608a/#cf9a33c5b6c489f24d04e5d2ac6c3a49f4064117


### PR DESCRIPTION
Updated mbed-os-atecc608a.lib with the latest master