### PR TITLE
Enable experimental api for Atecc608a example

### DIFF
--- a/atecc608a/mbed_app.json
+++ b/atecc608a/mbed_app.json
@@ -1,6 +1,7 @@
 {
     "target_overrides": {
         "*": {
+            "target.features_add" : ["EXPERIMENTAL_API"],
             "platform.stdio-baud-rate": 9600,
             "platform.stdio-convert-newlines": true,
             "mbed-trace.enable": 0


### PR DESCRIPTION
PSA Crypto is being marked as experimental. As this example depends on PSA Crypto, we need to enable the EXPERIMENTAL_API feature in order to use it.