### PR TITLE
Update mbed-os to its development branch

### DIFF
--- a/atecc608a/mbed-os.lib
+++ b/atecc608a/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/


### PR DESCRIPTION
Update the Mbed OS version pointed at by this example's development branch to the Mbed OS development branch. This ensures that the development branch will build using the latest mbed-os after a checkout and deploy.