### PR TITLE
Remove mbed_set_mbed_target_linker_script from CMakeLists.txt

### DIFF
--- a/atecc608a/CMakeLists.txt
+++ b/atecc608a/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}


### PR DESCRIPTION
This function has been removed from mbed-os.

This PR depends on https://github.com/ARMmbed/mbed-os/pull/14199