### PR TITLE
Update for mbed-os-6.8.0

### DIFF
--- a/atecc608a/CMakeLists.txt
+++ b/atecc608a/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/atecc608a/mbed-os.lib
+++ b/atecc608a/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0c6753bb821612eb72b5f682aed7ffcc98e80a1f
+https://github.com/ARMmbed/mbed-os/#26606218ad9d1ee1c8781aa73774fd7ea3a7658e


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.8.0 release of mbed-os. 