### PR TITLE
Fix build with Mbed CLI 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,9 @@ matrix:
         - pip install "intelhex>=1.3,<=2.2.1"
       script:
         - cd atecc608a ; echo atecc608a ;
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - cd ..
         - ccache -s
 

--- a/README.md
+++ b/README.md
@@ -7,42 +7,43 @@ The examples in this repository demonstrate how to use the ATECC608A secure elem
 
 ## Prerequisites
 
-* [Install Mbed CLI](https://os.mbed.com/docs/mbed-os/latest/tools/installation-and-setup.html).
+A target with I2C and power supply connections, connected to an ATECC608A secure element as shown in [Hardware interface](#hardware-interface).
 
-* [Install the arm-none-eabi-ggc toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
-  - The [cryptoauthlib](https://github.com/MicrochipTech/cryptoauthlib) which
-    this example depends on [does not build on
-    IAR](https://github.com/ARMmbed/mbed-os-example-atecc608a/issues/15),
-    [ARMC5 or
-    ARMC6](https://github.com/ARMmbed/mbed-os-example-atecc608a/issues/16).
+## Mbed OS build tools
 
-* A target with I2C and power supply connections, connected to an ATECC608A secure element as shown in [Hardware interface](#hardware-interface).
+### Mbed CLI 2
+Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner. If you are working with Mbed OS version prior to 6.5 then check the section [Mbed CLI 1](#mbed-cli-1).
+1. [Install Mbed CLI 2](https://os.mbed.com/docs/mbed-os/latest/build-tools/install-or-upgrade.html).
+1. From the command-line, import the example: `mbed-tools import mbed-os-example-atecc608a`
+1. Change the current directory to `mbed-os-example-atecc608a/atecc608a`.
 
+### Mbed CLI 1
+1. [Install Mbed CLI 1](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
+1. From the command-line, import the example: `mbed import mbed-os-example-atecc608a`
+1. Change the current directory to `mbed-os-example-atecc608a/atecc608a`.
 
-## Importing the example
+## Building and running
 
-From the command-line, import the example:
+1. Connect a USB cable between the USB port on the board and the host computer.
+1. Run the following command to build the example project, program the microcontroller flash memory and open a serial monitor:
 
-```sh
-git clone git@github.com:ARMmbed/mbed-os-example-atecc608a.git
-cd mbed-os-example-atecc608a/atecc608a
-mbed deploy
+    * Mbed CLI 2
+
+    ```bash
+    $ mbed-tools compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm
+    ```
+
+    * Mbed CLI 1
+
+    ```bash
+    $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm
+    ```
+
+Your PC may take a few minutes to compile your code.
+
+## Expected output
+
 ```
-
-## Compiling and running the example
-
-Invoke `mbed compile`, and specify the name of your platform and your toolchain
-(only `GCC_ARM` works at the moment). For example, for the GCC_ARM compiler:
-
-```sh
-mbed compile -t GCC_ARM -m K64F --flash --sterm
-```
-
-Your PC may take a few minutes to compile your code. At the end, you see the following result:
-
-```
-Image: ./BUILD/K64F/GCC_ARM/atecc608a.bin
---- Terminal on /dev/ttyACM0 - 9600,8,N,1 ---
 Serial Number:
 01 23 BA CF BA D3 29 CA EE
 

--- a/atecc608a/CMakeLists.txt
+++ b/atecc608a/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
 set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
-set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-atecc608a)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)


### PR DESCRIPTION
Mbed CLI 2 (mbed-tools and CMake support) has been in development for some time and seen some changes. This example's CMake definitions need to be updated accordingly:

`.travis.yml`:
* Update mbed-tools commands

`CMakeLists.txt`:
* Update the configuration path generated by mbed-tools

`README.md`:
* Add instructions for Mbed CLI 2

Fixes #62