### PR TITLE
Fix mbed_app.json

### DIFF
--- a/atecc608a/mbed_app.json
+++ b/atecc608a/mbed_app.json
@@ -2,7 +2,7 @@
     "target_overrides": {
         "*": {
             "target.features_add" : ["EXPERIMENTAL_API", "PSA"],
-            "extra_labels_add": ["MBED_PSA_SRV"],
+            "target.extra_labels_add": ["MBED_PSA_SRV"],
             "platform.stdio-baud-rate": 9600,
             "platform.stdio-convert-newlines": true,
             "mbed-trace.enable": 0


### PR DESCRIPTION
The correct configuration contains `target.extra_labels_add`. When `target` is missing, configuration check fails with Mbed CLI 1 but works nonetheless with Mbed CLI 2.