### PR TITLE
Add CircleCI to test Mbed CLI 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+# CircleCI 2.1 configuration file
+#
+version: 2.1
+commands:
+  compile:
+    parameters:
+      target:
+        type: string
+      profile:
+        type: string
+    steps:
+      - run: |
+          cd mbed-os-example-atecc608a/atecc608a
+          mbed compile -t GCC_ARM -m <<parameters.target>> --profile <<parameters.profile>>
+jobs:
+  build:
+    docker:
+      - image: mbedos/mbed-os-env:latest
+    working_directory: ~
+    steps:
+      - checkout:
+          path: mbed-os-example-atecc608a
+      - run: |
+          cd mbed-os-example-atecc608a/atecc608a
+          mbed-tools deploy
+      - compile:
+          target: "K64F"
+          profile: "develop"
+      - compile:
+          target: "K64F"
+          profile: "debug"
+      - compile:
+          target: "K64F"
+          profile: "release"
+      - compile:
+          target: "NRF52_DK"
+          profile: "develop"
+      - compile:
+          target: "NRF52_DK"
+          profile: "debug"
+      - compile:
+          target: "NRF52_DK"
+          profile: "release"


### PR DESCRIPTION
Most Mbed official examples use CircleCI to test Mbed CLI 1 compatibility. This is separate from Travis, and when Mbed CLI 1
support is removed we will remove CircleCI tests.

Notes:
* This PR is motivated by this comment: https://github.com/ARMmbed/mbed-os-example-atecc608a/pull/66#pullrequestreview-660769949
* Preceding PR: https://github.com/ARMmbed/mbed-os/pull/14664 (NRF52_DK will fail to build with Mbed CLI 1 until it's merged)