### PR TITLE
Update for mbed-os-6.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,3 +93,15 @@ matrix:
     - <<: *cmake-build-test
       name: "CMake atecc608a example - debug (K64F)"
       env: NAME=cmake_test TARGET_NAME=K64F PROFILE=debug CACHE_NAME=debug-K64F
+
+    - <<: *cmake-build-test
+      name: "CMake atecc608a example - develop (NRF52_DK)"
+      env: NAME=cmake_test TARGET_NAME=NRF52_DK PROFILE=develop CACHE_NAME=develop-NRF52_DK
+
+    - <<: *cmake-build-test
+      name: "CMake atecc608a example - release (NRF52_DK)"
+      env: NAME=cmake_test TARGET_NAME=NRF52_DK PROFILE=release CACHE_NAME=release-NRF52_DK
+
+    - <<: *cmake-build-test
+      name: "CMake atecc608a example - debug (NRF52_DK)"
+      env: NAME=cmake_test TARGET_NAME=NRF52_DK PROFILE=debug CACHE_NAME=debug-NRF52_DK

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The examples in this repository demonstrate how to use the ATECC608A secure elem
 
 A target with I2C and power supply connections, connected to an ATECC608A secure element as shown in [Hardware interface](#hardware-interface).
 
+Note: This example enables Mbed OS PSA. It is _not_ suitable for or compatible with TF-M which has its own PSA implementation
+(e.g. Arm TrustZone on Arm v8-M).
+
 ## Mbed OS build tools
 
 ### Mbed CLI 2

--- a/atecc608a/mbed-os.lib
+++ b/atecc608a/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#9738b27c7df897c29e9769911d6794ba3e5b3f19
+https://github.com/ARMmbed/mbed-os/#14e5d307bb6cdccb554b591ab2602d8d47e0b2d0

--- a/atecc608a/mbed_app.json
+++ b/atecc608a/mbed_app.json
@@ -1,7 +1,8 @@
 {
     "target_overrides": {
         "*": {
-            "target.features_add" : ["EXPERIMENTAL_API"],
+            "target.features_add" : ["EXPERIMENTAL_API", "PSA"],
+            "extra_labels_add": ["MBED_PSA_SRV"],
             "platform.stdio-baud-rate": 9600,
             "platform.stdio-convert-newlines": true,
             "mbed-trace.enable": 0
@@ -9,10 +10,6 @@
         "NRF52_DK": {
             "cryptoauthlib.i2c_sda": "P0_26",
             "cryptoauthlib.i2c_scl": "P0_27"
-        },
-        "SAML21J18A": {
-            "cryptoauthlib.i2c_sda": "PA08",
-            "cryptoauthlib.i2c_scl": "PA09"
         }
     },
     "macros": [

--- a/atecc608a/mbed_app.json
+++ b/atecc608a/mbed_app.json
@@ -2,7 +2,7 @@
     "target_overrides": {
         "*": {
             "target.features_add" : ["EXPERIMENTAL_API", "PSA"],
-            "extra_labels_add": ["MBED_PSA_SRV"],
+            "target.extra_labels_add": ["MBED_PSA_SRV"],
             "platform.stdio-baud-rate": 9600,
             "platform.stdio-convert-newlines": true,
             "mbed-trace.enable": 0


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.11.0 release of mbed-os. 