### PR TITLE
Update for mbed-os-6.12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+# CircleCI 2.1 configuration file
+#
+version: 2.1
+commands:
+  compile:
+    parameters:
+      target:
+        type: string
+      profile:
+        type: string
+    steps:
+      - run: |
+          cd mbed-os-example-atecc608a/atecc608a
+          mbed compile -t GCC_ARM -m <<parameters.target>> --profile <<parameters.profile>>
+jobs:
+  build:
+    docker:
+      - image: mbedos/mbed-os-env:latest
+    working_directory: ~
+    steps:
+      - checkout:
+          path: mbed-os-example-atecc608a
+      - run: |
+          cd mbed-os-example-atecc608a/atecc608a
+          mbed-tools deploy
+      - compile:
+          target: "K64F"
+          profile: "develop"
+      - compile:
+          target: "K64F"
+          profile: "debug"
+      - compile:
+          target: "K64F"
+          profile: "release"
+      - compile:
+          target: "NRF52_DK"
+          profile: "develop"
+      - compile:
+          target: "NRF52_DK"
+          profile: "debug"
+      - compile:
+          target: "NRF52_DK"
+          profile: "release"

--- a/atecc608a/mbed-os.lib
+++ b/atecc608a/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#14e5d307bb6cdccb554b591ab2602d8d47e0b2d0
+https://github.com/ARMmbed/mbed-os/#cecc47b4a53951527dd3f670465c8566396ad101


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.12.0 release of mbed-os. 