### PR TITLE
CMake: Make the application the top level CMake project

### DIFF
--- a/atecc608a/CMakeLists.txt
+++ b/atecc608a/CMakeLists.txt
@@ -9,6 +9,8 @@ set(APP_TARGET mbed-os-example-atecc608a)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-atecc608a)
@@ -16,8 +18,6 @@ add_subdirectory(mbed-os-atecc608a)
 add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE


### PR DESCRIPTION
So CMake can work correctly we need to define our project before we add
dependencies, otherwise the project we depend on will be registered as
the current project.