### PR TITLE
Update for mbed-os-6.15.0

### DIFF
--- a/atecc608a/mbed-os.lib
+++ b/atecc608a/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.15.0 release of mbed-os. 