### PR TITLE
Update for mbed-os-6.17.0

### DIFF
--- a/atecc608a/mbed-os.lib
+++ b/atecc608a/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f
+https://github.com/ARMmbed/mbed-os/#17dc3dc2e6e2817a8bd3df62f38583319f0e4fed


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.17.0 release of mbed-os. 